### PR TITLE
IFI-455 Include header cell title for screen readers

### DIFF
--- a/portal-web/docroot/html/taglib/ui/search_iterator/lexicon/list.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/lexicon/list.jsp
@@ -75,7 +75,7 @@ if (!resultRowSplitterEntries.isEmpty()) {
 							cssClass = (normalizedHeaderName.equals("rowChecker")) ? "lfr-checkbox-column" : "lfr-" + normalizedHeaderName + "-column";
 						}
 						else {
-							normalizedHeaderName = String.valueOf(i +1);
+							normalizedHeaderName = String.valueOf(i + 1);
 
 							cssClass = "lfr-entry-action-column";
 						}
@@ -140,6 +140,11 @@ if (!resultRowSplitterEntries.isEmpty()) {
 							%>
 
 							<c:choose>
+								<c:when test="<%= rowChecker != null && i == 0 %>">
+									<span class="sr-only">
+										<%= LanguageUtil.get(request, "selected-item") %>
+									</span>
+								</c:when>
 								<c:when test="<%= truncate %>">
 									<span class="truncate-text">
 										<%= headerNameValue %>


### PR DESCRIPTION
We had an empty table header sell which is confusing for screen reader users.

Test plan: In portal, go to left-hand sidebar -> Content -> Web Content, show table view. See screen-reader-only title in leftmost table header sell ("Selected Item").

Closes: https://issues.liferay.com/browse/IFI-455

<img width="1677" alt="screen_shot_2019-02-07_at_14_59_26_png" src="https://user-images.githubusercontent.com/7074/52448607-4f700a00-2ae9-11e9-9f8a-182f4957aef2.png">