### PR TITLE
LPD-94494 DEMO ONLY Swap to Ollama when OLLAMA_BASE_URL is set

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-impl/build.gradle
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 	compileInclude group: "dev.langchain4j", name: "langchain4j-http-client-jdk", version: "1.10.0"
 	compileInclude group: "dev.langchain4j", name: "langchain4j-open-ai", version: "1.10.0"
 	compileInclude group: "dev.langchain4j", name: "langchain4j-mcp", version: "1.10.0-beta18"
+	compileInclude group: "dev.langchain4j", name: "langchain4j-ollama", version: "1.10.0"
 	compileInclude group: "dev.langchain4j", name: "langchain4j-vertex-ai", version: "1.10.0-beta18"
 	compileInclude group: "dev.langchain4j", name: "langchain4j-vertex-ai-gemini", version: "1.10.0-beta18"
 	compileInclude group: "io.grpc", name: "grpc-alts", version: "1.75.0"

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/model/VertexAiGeminiUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/model/VertexAiGeminiUtil.java
@@ -13,6 +13,7 @@ import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.service.ServiceContext;
 
 import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.ollama.OllamaStreamingChatModel;
 import dev.langchain4j.model.openai.OpenAiStreamingChatModel;
 import dev.langchain4j.model.vertexai.gemini.HarmCategory;
 import dev.langchain4j.model.vertexai.gemini.SafetyThreshold;
@@ -60,6 +61,27 @@ public class VertexAiGeminiUtil {
 	public static StreamingChatModel createStreamingChatModel(
 			QuotaManager quotaManager, ServiceContext serviceContext)
 		throws ConfigurationException {
+
+		String ollamaBaseURL = System.getenv("OLLAMA_BASE_URL");
+
+		if ((ollamaBaseURL != null) && !ollamaBaseURL.isEmpty()) {
+			String ollamaModelName = System.getenv("OLLAMA_MODEL");
+
+			if ((ollamaModelName == null) || ollamaModelName.isEmpty()) {
+				ollamaModelName = "gemma4:e4b";
+			}
+
+			return OllamaStreamingChatModel.builder(
+			).baseUrl(
+				ollamaBaseURL
+			).listeners(
+				Collections.singletonList(
+					new AIHubChatModelListenerImpl(
+						quotaManager, serviceContext))
+			).modelName(
+				ollamaModelName
+			).build();
+		}
 
 		String openAiApiKey = System.getenv("OPENAI_API_KEY");
 

--- a/modules/dxp/apps/ai-hub/demo/README.markdown
+++ b/modules/dxp/apps/ai-hub/demo/README.markdown
@@ -16,6 +16,7 @@ The REST endpoint requires session/cookie authentication: any non-Bearer `Author
 ## Runtime Prerequisites
 
 - Tomcat started with `OPENAI_API_KEY` exported (the demo branch swaps Vertex for OpenAI `gpt-4o-mini` when the variable is present).
+- Alternatively, export `OLLAMA_BASE_URL` (e.g. `http://192.168.40.33:11434`) to run against a local Ollama server instead — it takes precedence over OpenAI. The model defaults to `gemma4:e4b` and can be overridden with `OLLAMA_MODEL`; it must be a vision-capable model. Validated against the raw Ollama API with the agent's prompt: the informative sample resolved to a correct (if less detailed) alt text in ~20s and the decorative sample returned a fully empty response, so the `alt=""` contract holds locally and no image ever leaves the network.
 - `feature.flag.LPD-62272=true` in `portal-ext.properties` (gates all AI Hub REST).
 - Runtime flag `LPS-178052` enabled (headless site-pages POST), e.g. via `POST /o/com-liferay-feature-flag-web/set-enabled`.
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94494

## What Is This

Conceptual, **untested** change showing the effort required to point the alt text demo at a local AI server (Ollama) instead of OpenAI. It is meant for review only — do not merge or deploy as is.

## How It Works

When `OLLAMA_BASE_URL` is exported (e.g. `http://192.168.40.33:11434`), `VertexAiGeminiUtil.createStreamingChatModel` builds an `OllamaStreamingChatModel` against that server, taking precedence over the OpenAI swap. The model comes from `OLLAMA_MODEL` and defaults to `gemma4:e4b`; it must be vision capable. Without the variable, nothing changes.

The multimodal pipeline (`ImageContent` as base64) matches what the Ollama API expects, so the agent, the workflow, and the fragments stay untouched — the swap is one dependency plus ~20 lines.

## Validation Done So Far

The model itself was exercised against the raw Ollama API using the agent prompt:

| Case | Response | Time |
| --- | --- | --- |
| Informative (product card) | "Blue urban bike with front and rear wheels." | ~20s |
| Decorative (gradient) | empty response | ~40s |

The decorative `alt=""` contract holds locally, and no image leaves the network — the privacy angle for on-premise customers.

## Estimated Remaining Effort

About one hour: build the jar (expect OSGi `Import-Package` exclusions to surface in `bnd.bnd`, as happened with the OpenAI swap), deploy, and restart Tomcat with the environment variable.

## Why Are There No Tests?

Demo-only branch, conceptual change to illustrate effort; intentionally not built or deployed.

## PR Check

**pr-check: SKIPPED** — demo-only conceptual change, never to be merged

<!-- pr-check {"reason": "demo-only conceptual change, never to be merged", "result": "skipped", "sha": "887ef53a11518"} -->